### PR TITLE
Improvements for the R650.

### DIFF
--- a/vectors/r650.fct
+++ b/vectors/r650.fct
@@ -1,13 +1,6 @@
 # Bus Driver R650
 #
 #
-# First, every line starting with a '#' will be treated as a comment line
-# Blank lines will also be skipped.
-
-# Those two following lines are just helpers to make it easier to configure the right pin.
-#       AAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBB
-#       ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV
-
 # The 'config' key describes how the tested board has it connections.
 #
 # 'p' - power pin, do nothing
@@ -17,31 +10,35 @@
 # 'd' - pull down net on tested board
 # 'g' - pin should be grounded on tested board
 # '-' - pin should not be used, don't care and it will be electrically disconnected
+
 #       AAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBB
 #       ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV
-# For now, let's leave the H & S, F & R, L & V inputs to float
-# Might be nice in the future to add a third "floating" state for an input
-config='pppii--oo--ii--oo-------------------'
+config='pppii--ooo-ii--ooo------------------'
 
-# There can be multiple 'vector' keys. They are processed in order from top to bottom in the file.
-# If pin is configured to input, '01T' are valid configurations. 'T' toggles one pin only (one T per row)
-# and it's purpose is for debugging and half manual tests.
-# If the pin is configured as output, the pin value will be checked against
-# the given value (only '0' and '1' is valid) after all inputs has been set.
-#
 # From the datasheet: The diode inputs D and E (N and P) are the principle inputs.
 # They form a NAND gate for negative inputs or a NOR gate for ground inputs.
 #
 # We can ignore the F(R) input as it just bypasses the input diodes.
-# Similarly, we can ignore the L(V) input as it only bypasses the first stage.
+# The L(V) input is configured as an output here to monitor state of the first stage.
+# This helps to diagnose failures by showing the output of the first stage transistor.
 #
+# Bus Driver 1
 #       AAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBB
 #       ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV
-#       pppii--oo--ii--oo-------------------
-vector='---00--11--00--11-------------------'
-vector='---01--11--01--11-------------------'
-vector='---10--11--10--11-------------------'
-vector='---11--00--11--00-------------------'
+#       pppii--ooo-ii--ooo------------------
+vector='---00--111-11--000------------------'
+vector='---01--111-11--000------------------'
+vector='---10--111-11--000------------------'
+vector='---11--000-11--000------------------'
+
+# Bus Driver 2
+#       AAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBB
+#       ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV
+#       pppii--ooo-ii--ooo------------------
+vector='---11--000-00--111------------------'
+vector='---11--000-01--111------------------'
+vector='---11--000-10--111------------------'
+vector='---11--000-11--000------------------'
 
 # load-* keys are used to define limit values for tests of load networks
 # present on some boards. Used when the 'd' operator is found in the config string.
@@ -70,16 +67,15 @@ toggles='1000'
 # Outputs can only be loaded to -3V. The output value is not used but can be
 # useful. The L defines which outputs that should be tested. They can be on
 # a single line but can also be on several rows.
-
+#
+# Skip the non-coax outputs as the output is already tested in the coax case
 
 #             AAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBB
 #             ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV
 #             pppii--oo--ii--oo-------------------
 output-drive='---11------00-----------------------'
-#output-drive='---11--L---00-----------------------' # skip non-coax output
 output-drive='---11---L--00-----------------------'
 output-drive='---00------11-----------------------'
-#output-drive='---00------11--L--------------------' # skip non-coax output
 output-drive='---00------11---L-------------------'
 
 


### PR DESCRIPTION
Improvements for the R650.
Added the intermediate outputs. Useful in debugging faulty modules. 
Split out each bus driver test to run sequentially. 
Tidied comments about coax outputs. Removed commented vectors.