### PR TITLE
Fixed bug where DCD level input was inactive when toggling pulse input

### DIFF
--- a/vectors/s603.fct
+++ b/vectors/s603.fct
@@ -94,7 +94,7 @@ vector='---111-1111-1111-1------------------'
 vector='---111-1111-1101-1------------------'
 # Toggle the pulse input and observe the pulse on an oscilloscope
 # Ignore the output here as it's much too fast for polling on the ADC
-vector='---111-1111-1T1--1------------------'
+vector='---111-1111-1T0--1------------------'
 # Reset everything to inactive
 vector='---111-1111-1111-1------------------'
 


### PR DESCRIPTION
Fixed issue where DCD level input was inactive when toggling pulse input. This resulted in a single pulse output rather than a sequence which hindered testing with a scope.