### PR TITLE
Added features to aid in debugging long vector files.

### DIFF
--- a/brs.c
+++ b/brs.c
@@ -270,10 +270,10 @@ int main (int argc, char *argv[])
         while (l < args.loops) {
             int k=0;
             printf("AAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBB\n");
-            printf("ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV\n");
+            printf("ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV [ Line|Result]\n");
             while(vectors[k].vector != NULL) {
                 if  (vectors[k].type == TYPE_LOGIC) {
-                    tests_checkLogic(board_config, vectors[k].vector, args.single_step);
+                    tests_checkLogic(board_config, vectors[k].vector, vectors[k].line_number, args.single_step);
                 }
                 k++;
             }
@@ -286,8 +286,8 @@ int main (int argc, char *argv[])
         while(vectors[k].vector != NULL) {
             if  (vectors[k].type == TYPE_OUTPUT) {
                 printf("AAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBB\n");
-                printf("ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV\n");
-                tests_checkDriveStrength(board_config, vectors[k].vector, args.single_step);
+                printf("ABCDEFHJKLMNPRSTUVABCDEFHJKLMNPRSTUV [ Line|Result]\n");
+                tests_checkDriveStrength(board_config, vectors[k].vector, vectors[k].line_number, args.single_step);
             }
             if (vectors[k].type == TYPE_DEBUG_EXIT) {
                 return 0;

--- a/docs/BRS-Tester-User-s-Manual.md
+++ b/docs/BRS-Tester-User-s-Manual.md
@@ -414,6 +414,8 @@ Test Vector files are ASCII text and can be created and edited with any text edi
 
 Test Vector files contain several types of lines that are described below.
 
+Syntax highlighting support for vector files in Emacs and Vim/Neovim is included in the support directory.
+
 Note: Comment lines begin with “#”, and blank lines will be ignored.
 
 ### 5.1. Config Line

--- a/hal.h
+++ b/hal.h
@@ -5,6 +5,10 @@
  *
  */
 
+#ifndef HAL_H
+#define HAL_H
+
+
 /*
  * Definition of PIN vs number
  */
@@ -78,3 +82,5 @@ int pin_setGnd(enum fc_pin pin, int data);
 int pin_getValue(enum fc_pin pin, int *val);
 int pin_getName(enum fc_pin pin, char **str);
 enum fc_pin pin_getIndex(char *str);
+
+#endif /* HAL_H */

--- a/support/fct-mode.el
+++ b/support/fct-mode.el
@@ -1,0 +1,86 @@
+;;; fct-mode.el --- Major mode for BRS .fct test vector files
+;;
+;; Installation:
+;;
+;;   Save this file somewhere in your load-path (for example
+;;   ~/.emacs.d/lisp/) and add the following to your init.el:
+;;
+;;     (require 'fct-mode)
+;;
+;;   Files ending in ".fct" will then automatically use FCT mode.
+
+(defgroup fct nil
+  "Major mode for BRS functional test files."
+  :group 'languages)
+
+(defface fct-assignment-keyword-face
+  '((t :inherit font-lock-keyword-face))
+  "Face used for assignment keywords.")
+
+(defface fct-assignment-value-face
+  '((t :inherit font-lock-string-face))
+  "Face used for assignment values.")
+
+(defconst fct-assignment-keywords
+  '("vector"
+    "config"
+    "load-low"
+    "toggles"
+    "load-low-margin"
+    "load-high"
+    "load-high-margin"
+    "load-current"
+    "load-current-margin"
+    "input-current-margin"
+    "input-voltage-high"
+    "input-current-high"
+    "input-voltage-low"
+    "input-current-low"
+    "output-drive"
+    "output-drive-strength"
+    "output-voltage-high"
+    "output-voltage-margin"
+    )
+  "Keywords used on assignment lines.")
+
+(defconst fct-assignment-regexp
+  (concat
+   "^\\s-*"
+   "\\(" (regexp-opt fct-assignment-keywords t) "\\)"
+   "\\s-*=\\s-*"
+   "\\('\\(?:[^'\n]\\)*'\\)"
+   "\\s-*$"))
+
+(defconst fct-font-lock-keywords
+  `(
+    ;; Whole line comments.
+    ("^\\s-*#.*$"
+     . font-lock-comment-face)
+
+    ;; Assignment lines.
+    (,fct-assignment-regexp
+     (1 'fct-assignment-keyword-face)
+     (2 'fct-assignment-value-face)))
+  "Font lock keywords for FCT mode.")
+
+;;;###autoload
+(define-derived-mode fct-mode prog-mode "FCT"
+  "Major mode for editing BRS test vector files."
+
+  ;; '#' starts a comment, newline ends it.
+  (modify-syntax-entry ?# "<" fct-mode-syntax-table)
+  (modify-syntax-entry ?\n ">" fct-mode-syntax-table)
+
+  ;; Comment commands.
+  (setq-local comment-start "# ")
+  (setq-local comment-end "")
+
+  ;; Font locking.
+  (setq-local font-lock-defaults
+              '(fct-font-lock-keywords)))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist
+             '("\\.fct\\'" . fct-mode))
+
+(provide 'fct-mode)

--- a/support/vimrc
+++ b/support/vimrc
@@ -1,0 +1,50 @@
+" ============================================================================
+" FCT syntax highlighting
+"
+" To install:
+"   1. Copy this block into your ~/.vimrc (or ~/.config/nvim/init.vim).
+"   2. Restart Vim/Neovim.
+"
+" Files ending in .fct will automatically use this syntax highlighting.
+" ============================================================================
+
+" Detect .fct files
+augroup fct_filetype
+  autocmd!
+  autocmd BufRead,BufNewFile *.fct setfiletype fct
+augroup END
+
+" Define FCT syntax
+augroup fct_syntax
+  autocmd!
+  autocmd FileType fct call s:DefineFctSyntax()
+augroup END
+
+function! s:DefineFctSyntax() abort
+  syntax clear
+
+  " Whole line comments
+  syntax match fctComment "^\s*#.*$"
+
+  " Assignment keywords (only when followed by '=')
+  syntax match fctAssignmentKeyword
+        \ "^\s*\zs\%(vector\|config\|load-low\|toggles\|load-low-margin\|load-high\|load-high-margin\|load-current\|load-current-margin\|input-current-margin\|input-voltage-high\|input-current-high\|input-voltage-low\|input-current-low\|output-drive\|output-drive-strength\|output-voltage-high\|output-voltage-margin\)\ze\s*="
+
+  " Single quoted assignment values
+  syntax region fctAssignmentValue
+        \ start=/'/
+        \ end=/'/
+        \ contained
+
+  " Assignment lines
+  syntax match fctAssignmentLine
+        \ "^\s*\%(vector\|config\|load-low\|toggles\|load-low-margin\|load-high\|load-high-margin\|load-current\|load-current-margin\|input-current-margin\|input-voltage-high\|input-current-high\|input-voltage-low\|input-current-low\|output-drive\|output-drive-strength\|output-voltage-high\|output-voltage-margin\)\s*=.*$"
+        \ contains=fctAssignmentKeyword,fctAssignmentValue
+
+  " Highlight groups
+  highlight default link fctComment Comment
+  highlight default link fctAssignmentKeyword Keyword
+  highlight default link fctAssignmentValue String
+
+  let b:current_syntax = "fct"
+endfunction

--- a/tests.c
+++ b/tests.c
@@ -16,6 +16,9 @@
 #include "tests.h"
 #include "vector.h"
 
+static const char *const TEST_PASS = TERM_GREEN TERM_BOLD " OK " TERM_RESET;
+static const char *const TEST_FAIL = TERM_RED   TERM_BOLD "FAIL" TERM_RESET;
+
 static void waitUserInput(bool wait)
 {
     if (wait) {
@@ -47,7 +50,7 @@ int tests_selfTest(void)
         voltage_ref_ok = 1;
     }
 
-    printf("Reference voltage: %7.1f mV (1700.0 mV)                              [ %s ]\n", voltage_ref, voltage_ref_ok ? " OK " : "FAIL");
+    printf("Reference voltage: %7.1f mV (1700.0 mV)                              [ %s ]\n", voltage_ref, voltage_ref_ok ? TEST_PASS : TEST_FAIL);
 
     /*
      * Loop through all PINS and test them, high, low and with load.
@@ -109,9 +112,9 @@ int tests_selfTest(void)
 
             printf("PIN %s, D '1':%d (%7.1f mV) [%s], D '0':%d (%7.1f mV) [%s], I -4 mA: %7.1f mA [%s]\n",
                     str,
-                    data_h, voltage_h, (data_h && voltage_h_ok) ? " OK " : "FAIL",
-                    data_l, voltage_l, (!data_l && voltage_l_ok) ? " OK " : "FAIL",
-                    current, current_ok ? " OK " : "FAIL");
+                    data_h, voltage_h, (data_h && voltage_h_ok) ? TEST_PASS : TEST_FAIL,
+                    data_l, voltage_l, (!data_l && voltage_l_ok) ? TEST_PASS : TEST_FAIL,
+                    current, current_ok ? TEST_PASS : TEST_FAIL);
             pin_setMeasure(k, 0);
             pin_setFunction(k, PIN_DISABLED);
         }
@@ -148,7 +151,7 @@ int tests_selfTest(void)
         }
 
         printf("Load: %.2d Meas: (%7.1f mA) (%7.1f mA)                              [ %s ]\n",
-               curr * -1, current, currents[i], (current_ok) ? " OK " : "FAIL");
+               curr * -1, current, currents[i], (current_ok) ? TEST_PASS : TEST_FAIL);
     }
 
     pin_setFunction(AE, PIN_DISABLED);
@@ -176,7 +179,7 @@ int tests_selfTest(void)
         result = (fabs(current) > 28.0 && fabs(voltage) < 400.0);
 
         printf("Drive strength: %.2d mA, meas: (%7.1f mA) (%7.1f mV)                 [ %s ]\n",
-            32, current, voltage, (result) ? " OK " : "FAIL");
+            32, current, voltage, (result) ? TEST_PASS : TEST_FAIL);
 
         pin_setDataOut(pin, 1);
         pin_setMeasure(pin, 0);
@@ -323,7 +326,7 @@ int tests_checkVoltages(struct config const *b_cfg)
                 retVal = -1;
             }
 
-            printf("Pin: %s %c voltage %7.1f                 [ %s ]\n", pinName, str[pin], voltage, voltage_ok ? " OK " : "FAIL");
+            printf("Pin: %s %c voltage %7.1f                 [ %s ]\n", pinName, str[pin], voltage, voltage_ok ? TEST_PASS : TEST_FAIL);
             break;
         default:
             printf("ERROR: Format error\n");
@@ -403,9 +406,9 @@ int tests_checkPullDown(struct config const *b_cfg)
 
             printf("Pin: %s %c V_low: %7.1fmV [ %s ]  V_high: %7.1fmV [ %s ]  I: %7.1fmA [ %s ]\n",
                     pinName, str[pin],
-                    voltage_l, voltage_l_ok ? " OK " : "FAIL",
-                    voltage_h, voltage_h_ok ? " OK " : "FAIL",
-                    current, current_ok ? " OK " : "FAIL");
+                    voltage_l, voltage_l_ok ? TEST_PASS : TEST_FAIL,
+                    voltage_h, voltage_h_ok ? TEST_PASS : TEST_FAIL,
+                    current, current_ok ? TEST_PASS : TEST_FAIL);
             break;
         default:
             printf("ERROR: Format error\n");
@@ -513,7 +516,7 @@ int tests_checkLogic(struct config const *b_cfg, char *vector, int line_number, 
             return -1;
         }
     }
-    printf(" [ %3d | %s ]", line_number, test_failed ? "FAIL" : " OK ");
+    printf(" [ %3d | %s ]", line_number, test_failed ? TEST_FAIL : TEST_PASS);
     waitUserInput(singleStep);
     return 0;
 }
@@ -597,7 +600,7 @@ int tests_checkDriveStrength(struct config const *b_cfg, char *vector, int line_
                                                                       b_cfg->output_drive_strength,
                                                                       voltage,
                                                                       line_number,
-                                                                      result ? " ok " : "fail");
+                                                                      result ? TEST_PASS : TEST_FAIL);
             waitUserInput(singleStep);
 
             test_run = true;
@@ -670,7 +673,7 @@ int tests_checkInputs(struct config const *b_cfg)
             }
 
             printf("Pin: %s 0 V: %7.1fmV [ %s ]    I: %7.1fmA [ %s ]\n", str, voltage,
-                    voltage_result ? " OK " : "FAIL", current, current_result ? " OK " : "FAIL");
+                    voltage_result ? TEST_PASS : TEST_FAIL, current, current_result ? TEST_PASS : TEST_FAIL);
             pin_setDataOut(pin, 0);
             usleep(100000);
             hal_measureCurrent(&current);
@@ -688,7 +691,7 @@ int tests_checkInputs(struct config const *b_cfg)
                 current_result = 1;
             }
             printf("Pin: %s 1 V: %7.1fmV [ %s ]    I: %7.1fmA [ %s ]\n", str, voltage,
-                    voltage_result ? " OK " : "FAIL", current, current_result ? " OK " : "FAIL");
+                    voltage_result ? TEST_PASS : TEST_FAIL, current, current_result ? TEST_PASS : TEST_FAIL);
             pin_setMeasure(pin, 0);
             pin_setDataOut(pin, 0);
         }

--- a/tests.c
+++ b/tests.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 
 #include "hal.h"
+#include "tests.h"
 #include "vector.h"
 
 static void waitUserInput(bool wait)

--- a/tests.c
+++ b/tests.c
@@ -416,7 +416,7 @@ int tests_checkPullDown(struct config const *b_cfg)
 }
 
 
-int tests_checkLogic(struct config const *b_cfg, char *vector, bool singleStep)
+int tests_checkLogic(struct config const *b_cfg, char *vector, int line_number, bool singleStep)
 {
     char const *setup = b_cfg->pin_def;
     bool test_failed = false;
@@ -512,13 +512,13 @@ int tests_checkLogic(struct config const *b_cfg, char *vector, bool singleStep)
             return -1;
         }
     }
-    printf("      [ %s ]", test_failed ? "FAIL" : " OK ");
+    printf(" [ %3d | %s ]", line_number, test_failed ? "FAIL" : " OK ");
     waitUserInput(singleStep);
     return 0;
 }
 
 
-int tests_checkDriveStrength(struct config const *b_cfg, char *vector, bool singleStep)
+int tests_checkDriveStrength(struct config const *b_cfg, char *vector, int line_number, bool singleStep)
 {
     printf("%s\n", vector);
 
@@ -592,10 +592,11 @@ int tests_checkDriveStrength(struct config const *b_cfg, char *vector, bool sing
             /*
              * Do some limit testing. Compare voltage
              */
-            printf("Pin %s %3d mA  voltage %7.1f mV         [ %s ]", pinName,
-                                                                     b_cfg->output_drive_strength,
-                                                                     voltage,
-                                                                     result ? " ok " : "fail");
+            printf("Pin %s %3d mA  voltage %7.1f mV    [ %3d | %s ]", pinName,
+                                                                      b_cfg->output_drive_strength,
+                                                                      voltage,
+                                                                      line_number,
+                                                                      result ? " ok " : "fail");
             waitUserInput(singleStep);
 
             test_run = true;

--- a/tests.h
+++ b/tests.h
@@ -10,6 +10,19 @@
 
 #include "vector.h"
 
+/* ANSI/VT100 terminal escape sequences for coloured console output. */
+#define TERM_RESET        "\x1b[0m"
+#define TERM_RED          "\x1b[31m"
+#define TERM_GREEN        "\x1b[32m"
+#define TERM_YELLOW       "\x1b[33m"
+#define TERM_BLUE         "\x1b[34m"
+#define TERM_MAGENTA      "\x1b[35m"
+#define TERM_CYAN         "\x1b[36m"
+#define TERM_WHITE        "\x1b[37m"
+#define TERM_BOLD         "\x1b[1m"
+#define TERM_UNDERLINE    "\x1b[4m"
+
+
 /*
  * Do a electrical test of the tester itself
  */

--- a/tests.h
+++ b/tests.h
@@ -12,6 +12,6 @@ int tests_selfTest(void);
 int tests_setupBoard(struct config const *b_cfg);
 int tests_checkVoltages(struct config const *b_cfg);
 int tests_checkPullDown(struct config const *b_cfg);
-int tests_checkLogic(struct config const *b_cfg, char *vector, bool singleStep);
-int tests_checkDriveStrength(struct config const *b_cfg, char *vector, bool singleStep);
+int tests_checkLogic(struct config const *b_cfg, char *vector, int line_number, bool singleStep);
+int tests_checkDriveStrength(struct config const *b_cfg, char *vector, int line_number, bool singleStep);
 int tests_checkInputs(struct config const *b_cfg);

--- a/tests.h
+++ b/tests.h
@@ -5,6 +5,11 @@
  *
  */
 
+#ifndef TESTS_H
+#define TESTS_H
+
+#include "vector.h"
+
 /*
  * Do a electrical test of the tester itself
  */
@@ -15,3 +20,5 @@ int tests_checkPullDown(struct config const *b_cfg);
 int tests_checkLogic(struct config const *b_cfg, char *vector, int line_number, bool singleStep);
 int tests_checkDriveStrength(struct config const *b_cfg, char *vector, int line_number, bool singleStep);
 int tests_checkInputs(struct config const *b_cfg);
+
+#endif /* TESTS_H */

--- a/vector.c
+++ b/vector.c
@@ -188,6 +188,7 @@ int vector_loadVectors(char *filename, struct config *board)
             vectors[k].vector = malloc(VECTOR_LENGTH);
             strncpy(vectors[k].vector, &str[8], VECTOR_LENGTH);
             vectors[k].vector[VECTOR_LENGTH-1] = '\0';
+            vectors[k].line_number = i;
             k++;
             vectors[k].vector = NULL;
         } else if (0 == strncmp("output-drive='", str, 14)){
@@ -202,6 +203,7 @@ int vector_loadVectors(char *filename, struct config *board)
             vectors[k].vector = malloc(VECTOR_LENGTH);
             strncpy(vectors[k].vector, &str[14], VECTOR_LENGTH);
             vectors[k].vector[VECTOR_LENGTH-1] = '\0';
+            vectors[k].line_number = i;
             k++;
             vectors[k].vector = NULL;
         } else if (0 == strncmp("load-low='", str, sizeof("load-low='")-1)) {

--- a/vector.h
+++ b/vector.h
@@ -5,6 +5,9 @@
  *
  */
 
+#ifndef VECTOR_H
+#define VECTOR_H
+
 #define VECTOR_LENGTH 37
 
 struct config {
@@ -44,3 +47,5 @@ int vector_loadVectors(char *filename, struct config *board);
 void vector_freeVectors(void);
 void vector_initVectors(void);
 struct config *vector_allocConfig(void);
+
+#endif /* VECTOR_H */

--- a/vector.h
+++ b/vector.h
@@ -33,8 +33,9 @@ enum type {
 };
 
 struct vector {
-    char *vector;
+    char     *vector;
     enum type type;
+    int       line_number;
 };
 
 extern struct vector vectors[];


### PR DESCRIPTION
Display vector file line numbers to locate the failed test
Added include guards to fix issue with including headers
Added coloured highlighting of test results to spot issues in long tests
Added config files for syntax highlighting of vector files in emacs & vim/neovim