### PR TITLE
Fixed input thresholds and margins for W640 Triple Pulse Amplifier

### DIFF
--- a/vectors/w640.fct
+++ b/vectors/w640.fct
@@ -40,15 +40,15 @@ load-current='-10mA'
 load-current-margin='1mA'
 
 # input-* keys defined limits when testing inputs
-input-current-margin='0.2mA'
+input-current-margin='2mA'
 
 # For a digital '0'
 input-voltage-high='-10mV'
-input-current-high='-1.8mA'
+input-current-high='-5mA'
 
 # For a digital '1'
 input-voltage-low='-3700mV'
-input-current-low='0mA'
+input-current-low='3mA'
 
 # Number of times a pin should toggle when the 'T' function is used in the vector string.
 toggles='1000'


### PR DESCRIPTION
Fixed input thresholds and margins for W640 Triple Pulse Amplifier